### PR TITLE
Make saves work in 1.0

### DIFF
--- a/NoitaSaveManager/MainForm.cs
+++ b/NoitaSaveManager/MainForm.cs
@@ -223,7 +223,7 @@ namespace NoitaSaveManager
 
         private void GameHandler_GameFinished()
         {
-            if(File.Exists(Path.Combine(noitaSavePath, "player.salakieli")))
+            if(File.Exists(Path.Combine(noitaSavePath, "player.xml")) || File.Exists(Path.Combine(noitaSavePath, "player.salakieli")))
                 CreateGameSave(null, true);
         }
 

--- a/NoitaSaveManager/Noita/GameHandler.cs
+++ b/NoitaSaveManager/Noita/GameHandler.cs
@@ -87,11 +87,20 @@ namespace NoitaSaveManager.Noita
             if (Directory.Exists(Path.Combine(path, "world")))
                 Directory.Delete(Path.Combine(path, "world"), true);
 
+            if (File.Exists(Path.Combine(path, "magic_numbers.xml")))
+                File.Delete(Path.Combine(path, "magic_numbers.xml"));
+
             if (File.Exists(Path.Combine(path, "magic_numbers.salakieli")))
                 File.Delete(Path.Combine(path, "magic_numbers.salakieli"));
 
+            if (File.Exists(Path.Combine(path, "player.xml")))
+                File.Delete(Path.Combine(path, "player.xml"));
+
             if (File.Exists(Path.Combine(path, "player.salakieli")))
                 File.Delete(Path.Combine(path, "player.salakieli"));
+
+            if (File.Exists(Path.Combine(path, "world_state.xml")))
+                File.Delete(Path.Combine(path, "world_state.xml"));
 
             if (File.Exists(Path.Combine(path, "world_state.salakieli")))
                 File.Delete(Path.Combine(path, "world_state.salakieli"));

--- a/NoitaSaveManager/Noita/GameSave.cs
+++ b/NoitaSaveManager/Noita/GameSave.cs
@@ -179,8 +179,15 @@ namespace NoitaSaveManager.Noita
             if(File.Exists(Path.Combine(noitaPath, "player.salakieli")))
                 File.Copy(Path.Combine(noitaPath, "player.salakieli"), Path.Combine(Location, "player.salakieli"));
 
+            if (File.Exists(Path.Combine(noitaPath, "player.xml")))
+                File.Copy(Path.Combine(noitaPath, "player.xml"), Path.Combine(Location, "player.xml"));
+
             if (File.Exists(Path.Combine(noitaPath, "world_state.salakieli")))
                 File.Copy(Path.Combine(noitaPath, "world_state.salakieli"), Path.Combine(Location, "world_state.salakieli"));
+
+            if (File.Exists(Path.Combine(noitaPath, "world_state.xml")))
+                File.Copy(Path.Combine(noitaPath, "world_state.xml"), Path.Combine(Location, "world_state.xml"));
+
         }
 
         public void RestoreFromStore(string noitaPath)
@@ -193,8 +200,14 @@ namespace NoitaSaveManager.Noita
             if (File.Exists(Path.Combine(Location, "player.salakieli")))
                 File.Copy(Path.Combine(Location, "player.salakieli"), Path.Combine(noitaPath, "player.salakieli"));
 
+            if (File.Exists(Path.Combine(Location, "player.xml")))
+                File.Copy(Path.Combine(Location, "player.xml"), Path.Combine(noitaPath, "player.xml"));
+
             if (File.Exists(Path.Combine(Location, "world_state.salakieli")))
                 File.Copy(Path.Combine(Location, "world_state.salakieli"), Path.Combine(noitaPath, "world_state.salakieli"));
+
+            if (File.Exists(Path.Combine(Location, "world_state.xml")))
+                File.Copy(Path.Combine(Location, "world_state.xml"), Path.Combine(noitaPath, "world_state.xml"));
         }
 
         public void Delete()


### PR DESCRIPTION
In 1.0 saves seem to get generated with a mix of encrypted an unencrypted files. This makes all the save handling code check for both XML and Salakieli files.

It seems like on exit a new autosave is always created but the save you loaded from doesn't get updated. I get this is intentional to enable save scumming? :)